### PR TITLE
Update Diffuser to safely handle null values

### DIFF
--- a/jvm/diffuser/src/main/java/com/spotify/diffuser/diffuser/Diffuser.java
+++ b/jvm/diffuser/src/main/java/com/spotify/diffuser/diffuser/Diffuser.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -53,8 +54,7 @@ public final class Diffuser<A> {
 
     this.effect =
         value -> {
-          A cachedValue = cache.get();
-          if (cachedValue == null || didChange.test(cachedValue, value)) {
+          if (didChange.test(cache.get(), value)) {
             sideEffect.run(value);
           }
           cache.set(value);
@@ -226,6 +226,6 @@ public final class Diffuser<A> {
   }
 
   private static <A> boolean notEqual(A a, A b) {
-    return !b.equals(a);
+    return !Objects.equals(b, a);
   }
 }


### PR DESCRIPTION
### What has changed
- Currently `Diffuser` does not support null values, although this isn't obvious as the documentation mentions nothing about nullability and the Java doesn't really help here either
- This has, over the years, led to a lot of runtime crashes due to [`Diffuser#notEqual`](https://github.com/spotify/diffuser/blob/f6d3133ff19e9d56a2dbf3ac0a41e8468a4cc94d/jvm/diffuser/src/main/java/com/spotify/diffuser/diffuser/Diffuser.java#L229) not handling null values
- A NPE happens when we go from a non-null value to null
- This PR replaces the equality check with [`Object.equals()`](https://docs.oracle.com/javase/7/docs/api/java/util/Objects.html#equals%28java.lang.Object,%20java.lang.Object%29), which can handle null values safely