### PR TITLE
Fix generic parameter shadow warning

### DIFF
--- a/swift/Diffuser/Sources/Diffuser/diffuser/Diffuser.swift
+++ b/swift/Diffuser/Sources/Diffuser/diffuser/Diffuser.swift
@@ -49,10 +49,6 @@ public struct Diffuser<A> {
         self.effect(newValue)
     }
 
-    static func notEqual<A: Equatable>(a: A, b: A) -> Bool {
-        return a != b
-    }
-
     init(
         effect: @escaping Effect<A>,
         didChange: @escaping DidChange<A>
@@ -98,5 +94,9 @@ extension Diffuser where A: Equatable {
             children.forEach { diffuser in diffuser.run(newValue) }
         }
         self.init(effect: effect, didChange: Diffuser.notEqual)
+    }
+
+    static func notEqual(a: A, b: A) -> Bool {
+        return a != b
     }
 }


### PR DESCRIPTION
Resolves the warning “Generic parameter 'A' shadows generic parameter from outer scope with the same name; this is an error in Swift 6”. This is done by moving the function to the extension that adds methods on `Diffuser` when `A` is `Equatable`. That allows us to remove the local `A` generic parameter from the `notEqual(a:b:)` method.