### PR TITLE
Add intoAlways overload that accepts a list of diffusers

### DIFF
--- a/swift/Diffuser/Sources/Diffuser/diffuser/Combinators.swift
+++ b/swift/Diffuser/Sources/Diffuser/diffuser/Combinators.swift
@@ -31,6 +31,38 @@ public extension Diffuser {
         return Diffuser(effect: effect)
     }
 
+    /// Create a Diffuser which merges a list of Diffusers and always executes them regardless of the value.
+    ///
+    /// This function is useful as a building block for more complex Diffusers, but it is unlikely that you would use
+    /// it on its own. Consider using `into` instead.
+    ///
+    /// - Parameter children: The list of Diffusers to merge
+    /// - Returns: A merged Diffuser which forwards any values it is `run` with to all
+    /// its children.
+    static func intoAlways(
+        _ children: [Diffuser<A>]
+    ) -> Diffuser<A> {
+        .intoAlways { value in
+            for child in children {
+                child.run(value)
+            }
+        }
+    }
+
+    /// Create a Diffuser which merges a list of Diffusers and always executes them regardless of the value.
+    ///
+    /// This function is useful as a building block for more complex Diffusers, but it is unlikely that you would use
+    /// it on its own. Consider using `into` instead.
+    ///
+    /// - Parameter children: The list of Diffusers to merge
+    /// - Returns: A merged Diffuser which forwards any values it is `run` with to all
+    /// its children.
+    static func intoAlways(
+        _ children: Diffuser<A>...
+    ) -> Diffuser<A> {
+        .intoAlways(children)
+    }
+
     /// Add an additional layer of caching to an existing Diffuser.
     ///
     /// This function is useful as a building block for more complex Diffusers, but it is unlikely that you would use

--- a/swift/Diffuser/Sources/Diffuser/diffuser/Combinators.swift
+++ b/swift/Diffuser/Sources/Diffuser/diffuser/Combinators.swift
@@ -33,10 +33,25 @@ public extension Diffuser {
 
     /// Create a Diffuser which merges a list of Diffusers and always executes them regardless of the value.
     ///
-    /// This function is useful as a building block for more complex Diffusers, but it is unlikely that you would use
-    /// it on its own. Consider using `into` instead.
+    /// This function is useful as a building block for more complex Diffusers when using non-`Equatable` values
+    /// that have `Equatable` members. If the value is `Equatable`, consider using `intoAll` instead.
     ///
-    /// - Parameter children: The list of Diffusers to merge
+    /// For example, using this function it is possible to create composite Diffusers without conforming the model
+    /// to `Equatable`:
+    ///
+    /// ```Swift
+    /// struct Model {
+    ///     let a: String
+    ///     let b: String
+    /// }
+    ///
+    /// let diffuser: Diffuser<Model> = .intoAlways([
+    ///    .map(\.a, .into { a in /* ... */ }),
+    ///    .map(\.b, .into { b in /* ... */ }),
+    /// ])
+    /// ```
+    ///
+    /// - Parameter children: The list of Diffusers to merge.
     /// - Returns: A merged Diffuser which forwards any values it is `run` with to all
     /// its children.
     static func intoAlways(
@@ -51,10 +66,25 @@ public extension Diffuser {
 
     /// Create a Diffuser which merges a list of Diffusers and always executes them regardless of the value.
     ///
-    /// This function is useful as a building block for more complex Diffusers, but it is unlikely that you would use
-    /// it on its own. Consider using `into` instead.
+    /// This function is useful as a building block for more complex Diffusers when using non-`Equatable` values
+    /// that have `Equatable` members. If the value is `Equatable`, consider using `intoAll` instead.
     ///
-    /// - Parameter children: The list of Diffusers to merge
+    /// For example, using this function it is possible to create composite Diffusers without conforming the model
+    /// to `Equatable`:
+    ///
+    /// ```Swift
+    /// struct Model {
+    ///     let a: String
+    ///     let b: String
+    /// }
+    ///
+    /// let diffuser: Diffuser<Model> = .intoAlways(
+    ///    .map(\.a, .into { a in /* ... */ }),
+    ///    .map(\.b, .into { b in /* ... */ })
+    /// )
+    /// ```
+    ///
+    /// - Parameter children: The list of Diffusers to merge.
     /// - Returns: A merged Diffuser which forwards any values it is `run` with to all
     /// its children.
     static func intoAlways(


### PR DESCRIPTION
A common pattern is to create a `Diffuser` that is a combination of several diffusers that map individual properties of the model:

```Swift
let diffuser: Diffuser<Model> = .intoAll([
    .map(\.propertyOne, .into { /* do something with propertyOne */ },
    .map(\.propertyTwo, .into { /* do something with propertyTwo */ }
])
```

This works fine except that it forces you to make the model `Equatable` because `intoAll` requires the object to be `Equatable`. When using this pattern, you don't care about the model being `Equatable` but only about the individual properties being `Equatable`, in fact the entire object will be cached by `intoAll` and then each property will be cached by `into`.

To avoid this unnecessary conformance to `Equatable`, this PR introduces a variant of `intoAlways` that accepts a list of diffusers and always run them making the previous example:

```Swift
let diffuser: Diffuser<Model> = .intoAlways([
    .map(\.propertyOne, .into { /* do something with propertyOne */ },
    .map(\.propertyTwo, .into { /* do something with propertyTwo */ }
])
```

Since the individual properties are still `Equatable` as required by `.into`, the two examples above are pretty much equivalent.